### PR TITLE
Added filter config which was missing while making pivotUIOptions Object

### DIFF
--- a/pivot.coffee
+++ b/pivot.coffee
@@ -669,6 +669,7 @@ $.fn.pivotUI = (input, inputOpts, overwrite = false) ->
                 hiddenAttributes: opts.hiddenAttributes
                 renderers: opts.renderers
                 aggregators: opts.aggregators
+                filter: opts.filter
                 derivedAttributes: opts.derivedAttributes
                 aggregatorName: aggregator.val()
                 rendererName: renderer.val()


### PR DESCRIPTION
I found a statement missing as I was using pivot.js. I have added that statement in .coffee file.
Since filter was missing therefore the opts.filter(record) line was throwing exception.
