### PR TITLE
adding feature to make inspection of individual records possible

### DIFF
--- a/examples/drilldown_hack.html
+++ b/examples/drilldown_hack.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Pivot Demo</title>
+		<link rel="stylesheet" type="text/css" href="pivot.css">
+		<script type="text/javascript" src="jquery-1.8.3.min.js"></script>
+		<script type="text/javascript" src="jquery-ui-1.9.2.custom.min.js"></script>
+		<script type="text/javascript" src="pivot.js"></script>
+	</head>
+	<style>
+		* {font-family: Verdana;}
+		.pvtTable td {
+			cursor: pointer;
+		}
+		#row_output {
+			font-size: 90%;
+		}
+		#row_output th {
+			background-color: #333;
+			color:#fff;
+			padding:2px 5px;
+		}
+	</style>
+	<body>
+<script type="text/javascript">
+	$(function(){
+		$("#output").pivotUI(
+			[
+				{country: "USA", order_id: 1, payment_source: "Credit Card", order_total: 10},
+				{country: "USA", order_id: 2, payment_source: "PayPal", order_total: 50},
+				{country: "USA", order_id: 3, payment_source: "Credit Card", order_total: 30},
+				{country: "USA", order_id: 4, payment_source: "PayPal", order_total: 20},
+				{country: "USA", order_id: 5, payment_source: "Credit Card", order_total: 25},
+				{country: "USA", order_id: 6, payment_source: "PayPal", order_total: 71},
+				{country: "Canada", order_id: 7, payment_source: "Credit Card", order_total: 12},
+				{country: "Canada", order_id: 8, payment_source: "PayPal", order_total: 15},
+				{country: "Canada", order_id: 9, payment_source: "Credit Card", order_total: 92},
+			],
+			{
+				rows: ["country"],
+				cols: ["payment_source"],
+				vals: ["order_total"],
+				aggregatorName: "sum",
+				capture:true,
+			}
+		).on('click','td',function(e) {
+			e.stopPropagation();
+		 	console.log($(this).data('records'));
+			drawRecords($(this).data('records'),$('#row_output'));
+		});
+	});
+
+	function drawRecords(d,t) {
+		var $table = $('#global-records').empty();
+		if(!$table.length) 
+			$table = $('<table>').attr('id','global-records').appendTo(t);
+		console.log(d);
+		if(d[0]) {
+			var $thead = $('<thead>');
+			var $row = $('<tr>').appendTo($thead);
+			$.each(d[0],function(k,v){
+				$row.append($('<th>').text(k));
+			});
+			var $tbody = $('<tbody>');
+			$.each(d,function(i,row){
+				$row = $('<tr>').appendTo($tbody);
+				$.each(row,function(key,val){
+					$row.append($('<td>').text(val));
+				});
+			})
+			$table.append($thead).append($tbody);
+		}
+	}
+</script>
+
+		<div id="output" style="margin: 10px;"></div>
+
+		<div id="row_output">
+
+		</div>
+	</body>
+</html>

--- a/examples/pivot.js
+++ b/examples/pivot.js
@@ -301,6 +301,18 @@
 
   aggregators.countAsFractionOfCol = aggregatorTemplates.fractionOf(aggregators.count, "col");
 
+  monkeyPatchCapture = function(aggregator) {
+    return (function(){
+      var agg = aggregator();
+      _push = agg.push;
+      agg.push = function(r){
+        (this.records = this.records || []).push(r);
+        return _push.apply(this,arguments);
+      }
+      return agg;
+    });
+  }
+
   renderers = {
     "Table": function(pvtData, opts) {
       return pivotTableRenderer(pvtData, opts);
@@ -744,11 +756,11 @@
         colKey = colKeys[j];
         aggregator = pivotData.getAggregator(rowKey, colKey);
         val = aggregator.value();
-        tr.append($("<td class='pvtVal row" + i + " col" + j + "'>").html(aggregator.format(val)).data("value", val));
+        tr.append($("<td class='pvtVal row" + i + " col" + j + "'>").html(aggregator.format(val)).data("value", val).data("records",aggregator.records));
       }
       totalAggregator = pivotData.getAggregator(rowKey, []);
       val = totalAggregator.value();
-      tr.append($("<td class='pvtTotal rowTotal'>").html(totalAggregator.format(val)).data("value", val).data("for", "row" + i));
+      tr.append($("<td class='pvtTotal rowTotal'>").html(totalAggregator.format(val)).data("value", val).data("for", "row" + i).data("records",totalAggregator.records));
       result.append(tr);
     }
     tr = $("<tr>");
@@ -760,11 +772,11 @@
       colKey = colKeys[j];
       totalAggregator = pivotData.getAggregator([], colKey);
       val = totalAggregator.value();
-      tr.append($("<td class='pvtTotal colTotal'>").html(totalAggregator.format(val)).data("value", val).data("for", "col" + j));
+      tr.append($("<td class='pvtTotal colTotal'>").html(totalAggregator.format(val)).data("value", val).data("for", "col" + j).data("records",totalAggregator.records));
     }
     totalAggregator = pivotData.getAggregator([], []);
     val = totalAggregator.value();
-    tr.append($("<td class='pvtGrandTotal'>").html(totalAggregator.format(val)).data("value", val));
+    tr.append($("<td class='pvtGrandTotal'>").html(totalAggregator.format(val)).data("value", val).data("records",totalAggregator.records));
     result.append(tr);
     result.data("dimensions", [rowKeys.length, colKeys.length]);
     return result;
@@ -793,6 +805,7 @@
       }
     };
     opts = $.extend(defaults, opts);
+
     result = null;
     try {
       pivotData = getPivotData(input, opts.cols, opts.rows, opts.aggregator, opts.filter, opts.derivedAttributes);
@@ -841,6 +854,7 @@
       autoSortUnusedAttrs: false,
       rendererOptions: null,
       onRefresh: null,
+      capture:false,
       filter: function() {
         return true;
       },
@@ -1089,6 +1103,9 @@
           return vals.push($(this).data("attrName"));
         });
         subopts.aggregator = opts.aggregators[aggregator.val()](vals);
+        if(opts.capture) {
+          subopts.aggregator = monkeyPatchCapture(subopts.aggregator);
+        }
         subopts.renderer = opts.renderers[renderer.val()];
         exclusions = {};
         _this.find('input.pvtFilter').not(':checked').each(function() {


### PR DESCRIPTION
I needed the feature to drilldown to individual records.

Attached is a pull request.  I don't think you want to merge this, because it uses a monkey patch, and directly edits the .js file.  I tried to edit the .coffee file, but it didn't compile correctly... an issue with the coffee script version.

This code monkey patches the aggregator push function to add the records to the aggregator before reducing.  It then binds the underlying records to the <td> elements using $.fn.data.  

I have included an example html page that renders the the raw records when clicking on a cell.

I hope this is helpful.  Sorry for giving you half-assed code... I am not skilled enough with coffee-script to battle a version issue.
