### PR TITLE
Added an option for pivotTableRenderer for being able diplay html

### DIFF
--- a/dist/pivot.js
+++ b/dist/pivot.js
@@ -645,9 +645,13 @@
     defaults = {
       localeStrings: {
         totals: "Totals"
-      }
+      },
+	  thContent: "text"/*possible values: text,html*/
     };
     opts = $.extend(defaults, opts);
+	var thSetContent = "textContent";
+	if(opts.thContent == "html")
+		thSetContent = "innerHTML"
     colAttrs = pivotData.colAttrs;
     rowAttrs = pivotData.rowAttrs;
     rowKeys = pivotData.getRowKeys();
@@ -694,7 +698,7 @@
       }
       th = document.createElement("th");
       th.className = "pvtAxisLabel";
-      th.textContent = c;
+      th[thSetContent] = c;
       tr.appendChild(th);
       for (i in colKeys) {
         if (!__hasProp.call(colKeys, i)) continue;
@@ -703,7 +707,7 @@
         if (x !== -1) {
           th = document.createElement("th");
           th.className = "pvtColLabel";
-          th.textContent = colKey[j];
+          th[thSetContent] = colKey[j];
           th.setAttribute("colspan", x);
           if (parseInt(j) === colAttrs.length - 1 && rowAttrs.length !== 0) {
             th.setAttribute("rowspan", 2);
@@ -727,7 +731,7 @@
         r = rowAttrs[i];
         th = document.createElement("th");
         th.className = "pvtAxisLabel";
-        th.textContent = r;
+        th[thSetContent] = r;
         tr.appendChild(th);
       }
       th = document.createElement("th");
@@ -749,7 +753,7 @@
         if (x !== -1) {
           th = document.createElement("th");
           th.className = "pvtRowLabel";
-          th.textContent = txt;
+          th[thSetContent] = txt;
           th.setAttribute("rowspan", x);
           if (parseInt(j) === rowAttrs.length - 1 && colAttrs.length !== 0) {
             th.setAttribute("colspan", 2);

--- a/examples/simple_ui_th_html.html
+++ b/examples/simple_ui_th_html.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Pivot Demo</title>
+        <link rel="stylesheet" type="text/css" href="../dist/pivot.css">
+        <script type="text/javascript" src="ext/jquery-1.8.3.min.js"></script>
+        <script type="text/javascript" src="ext/jquery-ui-1.9.2.custom.min.js"></script>
+        <script type="text/javascript" src="../dist/pivot.js"></script>
+    </head>
+    <style>
+        * {font-family: Verdana;}
+    </style>
+    <body>
+        <script type="text/javascript">
+		$(function(){
+			$("#output").pivotUI(
+				[ 
+					{color: "blue", shape: "<i>circle</i>"}, 
+					{color: "red", shape: '<span style="color:red"triangle">triangle</span>'}
+				], 
+				{ 
+					rows: ["color"], 
+					cols: ["shape"],
+					rendererOptions:{
+						thContent: 'html'
+					}
+				}
+			);
+		});
+        </script>
+
+        <p><a href="index.html">&laquo; back to examples</a></p>
+        <div id="output" style="margin: 10px;"></div>
+
+    </body>
+</html>


### PR DESCRIPTION
Added an option for pivotTableRenderer for being able diplay html, thContent: text/html.
If someone needs to add images or other html to th it will be able to.
All started from this SO question: http://stackoverflow.com/q/26002789/832363
I also created an example: examples/simple_ui_th_html.html in order to show
how this option can be used.
