### PR TITLE
updated tag misalignment in example files

### DIFF
--- a/examples/d3.html
+++ b/examples/d3.html
@@ -8,18 +8,18 @@
         <script type="text/javascript" src="ext/jquery-ui-1.9.2.custom.min.js"></script>
         <script type="text/javascript" src="../dist/pivot.js"></script>
         <script type="text/javascript" src="../dist/d3_renderers.js"></script>
+        <style>
+            * {font-family: Verdana;}
+            .node {
+              border: solid 1px white;
+              font: 10px sans-serif;
+              line-height: 12px;
+              overflow: hidden;
+              position: absolute;
+              text-indent: 2px;
+            }
+        </style>
     </head>
-    <style>
-        * {font-family: Verdana;}
-        .node {
-          border: solid 1px white;
-          font: 10px sans-serif;
-          line-height: 12px;
-          overflow: hidden;
-          position: absolute;
-          text-indent: 2px;
-        }
-    </style>
     <body>
         <script type="text/javascript">
             $(function(){

--- a/examples/fully_loaded.html
+++ b/examples/fully_loaded.html
@@ -11,18 +11,18 @@
         <script type="text/javascript" src="../dist/gchart_renderers.js"></script>
         <script type="text/javascript" src="../dist/d3_renderers.js"></script>
         <script type="text/javascript" src="ext/jquery.ui.touch-punch.min.js"></script>
+        <style>
+            * {font-family: Verdana;}
+            .node {
+              border: solid 1px white;
+              font: 10px sans-serif;
+              line-height: 12px;
+              overflow: hidden;
+              position: absolute;
+              text-indent: 2px;
+            }
+        </style>
     </head>
-    <style>
-        * {font-family: Verdana;}
-        .node {
-          border: solid 1px white;
-          font: 10px sans-serif;
-          line-height: 12px;
-          overflow: hidden;
-          position: absolute;
-          text-indent: 2px;
-        }
-    </style>
     <body>
         <script type="text/javascript">
             google.load("visualization", "1", {packages:["corechart", "charteditor"]});

--- a/examples/gchart.html
+++ b/examples/gchart.html
@@ -8,10 +8,10 @@
         <script type="text/javascript" src="ext/jquery-ui-1.9.2.custom.min.js"></script>
         <script type="text/javascript" src="../dist/pivot.js"></script>
         <script type="text/javascript" src="../dist/gchart_renderers.js"></script>
+        <style>
+            * {font-family: Verdana;}
+        </style>
     </head>
-    <style>
-        * {font-family: Verdana;}
-    </style>
     <body>
         <script type="text/javascript">
             google.load("visualization", "1", {packages:["corechart", "charteditor"]});

--- a/examples/index.html
+++ b/examples/index.html
@@ -2,10 +2,10 @@
 <html>
     <head>
         <title>PivotTable.js</title>
+        <style>
+            * {font-family: Verdana;}
+        </style>
     </head>
-    <style>
-        * {font-family: Verdana;}
-    </style>
     <body style="width: 600px; margin: 10px auto;">
         <h2 align="center">PivotTable.js Demos</h2>
         <p align="center"><a href="https://github.com/nicolaskruchten/pivottable">https://github.com/nicolaskruchten/pivottable</a></p>

--- a/examples/local.html
+++ b/examples/local.html
@@ -11,18 +11,18 @@
         <script type="text/javascript" src="../dist/pivot.js"></script>
         <script type="text/javascript" src="../dist/gchart_renderers.js"></script>
         <script type="text/javascript" src="../dist/d3_renderers.js"></script>
+        <style>
+            * {font-family: Verdana;}
+            .node {
+              border: solid 1px white;
+              font: 10px sans-serif;
+              line-height: 12px;
+              overflow: hidden;
+              position: absolute;
+              text-indent: 2px;
+            }
+        </style>
     </head>
-    <style>
-        * {font-family: Verdana;}
-        .node {
-          border: solid 1px white;
-          font: 10px sans-serif;
-          line-height: 12px;
-          overflow: hidden;
-          position: absolute;
-          text-indent: 2px;
-        }
-    </style>
     <body>
         <script type="text/javascript">
             google.load("visualization", "1", {packages:["corechart", "charteditor"]});

--- a/examples/mps.html
+++ b/examples/mps.html
@@ -6,10 +6,10 @@
         <script type="text/javascript" src="ext/jquery-1.8.3.min.js"></script>
         <script type="text/javascript" src="ext/jquery-ui-1.9.2.custom.min.js"></script>
         <script type="text/javascript" src="../dist/pivot.js"></script>
+        <style>
+            * {font-family: Verdana;}
+        </style>
     </head>
-    <style>
-        * {font-family: Verdana;}
-    </style>
     <body>
         <script type="text/javascript">
             $(function(){

--- a/examples/mps_agg.html
+++ b/examples/mps_agg.html
@@ -6,10 +6,10 @@
         <script type="text/javascript" src="ext/jquery-1.8.3.min.js"></script>
         <script type="text/javascript" src="ext/jquery-ui-1.9.2.custom.min.js"></script>
         <script type="text/javascript" src="../dist/pivot.js"></script>
+        <style>
+            * {font-family: Verdana;}
+        </style>
     </head>
-    <style>
-        * {font-family: Verdana;}
-    </style>
     <body>
         <script type="text/javascript">
             $(function(){

--- a/examples/mps_csv.html
+++ b/examples/mps_csv.html
@@ -7,10 +7,10 @@
         <script type="text/javascript" src="ext/jquery-ui-1.9.2.custom.min.js"></script>
         <script type="text/javascript" src="ext/jquery.csv-0.71.min.js"></script>
         <script type="text/javascript" src="../dist/pivot.js"></script>
+        <style>
+            * {font-family: Verdana;}
+        </style>
     </head>
-    <style>
-        * {font-family: Verdana;}
-    </style>
     <body>
         <script type="text/javascript">
             $(function(){

--- a/examples/mps_export.html
+++ b/examples/mps_export.html
@@ -8,10 +8,10 @@
         <script type="text/javascript" src="ext/jquery-ui-1.9.2.custom.min.js"></script>
         <script type="text/javascript" src="../dist/pivot.js"></script>
         <script type="text/javascript" src="../dist/export_renderers.js"></script>
+        <style>
+            * {font-family: Verdana;}
+        </style>
     </head>
-    <style>
-        * {font-family: Verdana;}
-    </style>
     <body>
         <script type="text/javascript">
             $(function(){

--- a/examples/mps_fr.html
+++ b/examples/mps_fr.html
@@ -7,10 +7,10 @@
         <script type="text/javascript" src="ext/jquery-ui-1.9.2.custom.min.js"></script>
         <script type="text/javascript" src="../dist/pivot.js"></script>
         <script type="text/javascript" src="../dist/pivot.fr.js"></script>
+        <style>
+            * {font-family: Verdana;}
+        </style>
     </head>
-    <style>
-        * {font-family: Verdana;}
-    </style>
     <body>
         <script type="text/javascript">
             $(function(){

--- a/examples/mps_prepop.html
+++ b/examples/mps_prepop.html
@@ -6,10 +6,10 @@
         <script type="text/javascript" src="ext/jquery-1.8.3.min.js"></script>
         <script type="text/javascript" src="ext/jquery-ui-1.9.2.custom.min.js"></script>
         <script type="text/javascript" src="../dist/pivot.js"></script>
+        <style>
+            * {font-family: Verdana;}
+        </style>
     </head>
-    <style>
-        * {font-family: Verdana;}
-    </style>
     <body>
         <script type="text/javascript">
             $(function(){

--- a/examples/onrefresh.html
+++ b/examples/onrefresh.html
@@ -6,10 +6,10 @@
         <script type="text/javascript" src="ext/jquery-1.8.3.min.js"></script>
         <script type="text/javascript" src="ext/jquery-ui-1.9.2.custom.min.js"></script>
         <script type="text/javascript" src="../dist/pivot.js"></script>
+        <style>
+            * {font-family: Verdana;}
+        </style>
     </head>
-    <style>
-        * {font-family: Verdana;}
-    </style>
     <body>
         <script type="text/javascript">
             $(function(){

--- a/examples/simple.html
+++ b/examples/simple.html
@@ -6,10 +6,10 @@
         <script type="text/javascript" src="ext/jquery-1.8.3.min.js"></script>
         <script type="text/javascript" src="ext/jquery-ui-1.9.2.custom.min.js"></script>
         <script type="text/javascript" src="../dist/pivot.js"></script>
+        <style>
+            * {font-family: Verdana;}
+        </style>
     </head>
-    <style>
-        * {font-family: Verdana;}
-    </style>
     <body>
         <script type="text/javascript">
             $(function(){

--- a/examples/simple_ui.html
+++ b/examples/simple_ui.html
@@ -6,10 +6,10 @@
         <script type="text/javascript" src="ext/jquery-1.8.3.min.js"></script>
         <script type="text/javascript" src="ext/jquery-ui-1.9.2.custom.min.js"></script>
         <script type="text/javascript" src="../dist/pivot.js"></script>
+        <style>
+            * {font-family: Verdana;}
+        </style>
     </head>
-    <style>
-        * {font-family: Verdana;}
-    </style>
     <body>
         <script type="text/javascript">
             $(function(){

--- a/examples/simple_ui_from_table.html
+++ b/examples/simple_ui_from_table.html
@@ -6,10 +6,10 @@
         <script type="text/javascript" src="ext/jquery-1.8.3.min.js"></script>
         <script type="text/javascript" src="ext/jquery-ui-1.9.2.custom.min.js"></script>
         <script type="text/javascript" src="../dist/pivot.js"></script>
+        <style>
+            * {font-family: Verdana;}
+        </style>
     </head>
-    <style>
-        * {font-family: Verdana;}
-    </style>
     <body>
         <script type="text/javascript">
             $(function(){

--- a/examples/simple_ui_html_values.html
+++ b/examples/simple_ui_html_values.html
@@ -6,10 +6,10 @@
         <script type="text/javascript" src="ext/jquery-1.8.3.min.js"></script>
         <script type="text/javascript" src="ext/jquery-ui-1.9.2.custom.min.js"></script>
         <script type="text/javascript" src="../dist/pivot.js"></script>
+        <style>
+            * {font-family: Verdana;}
+        </style>
     </head>
-    <style>
-        * {font-family: Verdana;}
-    </style>
     <body>
         <script type="text/javascript">
             $(function(){


### PR DESCRIPTION
the html example files contained the following sequence
`    </head>`
`    <css />`
`    <body>`
In order to make the html valid, I changed that to 
`    <css />`
`    </head>`
`    <body>`
This corrects #267