### PR TITLE
Adding formatHeaders to rendererOptions

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -17,6 +17,7 @@
                 <li><a href="simple_function.html">pivot() with function input</a></li>
                 <li><a href="simple_ui.html">pivotUI() with "array of objects" input</a></li>
                 <li><a href="simple_ui_html_values.html">pivotUI() with HTML in attribute values</a></li>
+                <li><a href="simple_ui_format_labels.html">pivotUI() with HTML in attribute values rendered using formatHeaders</a></li>
                 <li><a href="simple_ui_from_table.html">pivotUI() with table element input</a></li>
             </ul>
         </li>

--- a/examples/simple_ui_format_labels.html
+++ b/examples/simple_ui_format_labels.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Pivot Demo</title>
+        <link rel="stylesheet" type="text/css" href="../dist/pivot.css">
+        <script type="text/javascript" src="ext/jquery-1.8.3.min.js"></script>
+        <script type="text/javascript" src="ext/jquery-ui-1.9.2.custom.min.js"></script>
+        <script type="text/javascript" src="../dist/pivot.js"></script>
+        <style>
+            * {font-family: Verdana;}
+        </style>
+    </head>
+    <body>
+        <script type="text/javascript">
+$(function() {
+    $("#output").pivotUI(
+        [ 
+            {color: "blue", shape: "circle"}, 
+            {color: "red", shape: "triangle"}
+        ], 
+        { 
+            rows: ["color"], 
+            cols: ["shape"],
+            rendererOptions: {
+                formatHeaders: function(attr, val) {
+                    if (attr == "color") {
+                        return "<span style='color: "+val+"'>"+val+"</span>";
+                    } else if (attr == "shape") {
+                        return {
+                            circle: "<span style='font-size:20px'>&bigcirc;</span>",
+                            triangle: "<span style='font-size:20px'>&bigtriangleup;</span>"
+                        }[val] || val;
+                    } else {
+                        return val;
+                    }
+                }
+            }
+        }
+    );
+});
+        </script>
+
+        <p><a href="index.html">&laquo; back to examples</a></p>
+
+        <p style="width: 800px">This example shows how to use formatHeaders to provide custom row and column headers.</p>
+
+        <div id="output" style="margin: 10px;"></div>
+
+    </body>
+</html>

--- a/pivot.coffee
+++ b/pivot.coffee
@@ -379,6 +379,8 @@ callWithJQuery ($) ->
         defaults =
             localeStrings:
                 totals: "Totals"
+            formatHeaders:
+                (attr, val) -> val
 
         opts = $.extend defaults, opts
 
@@ -426,7 +428,7 @@ callWithJQuery ($) ->
                 if x != -1
                     th = document.createElement("th")
                     th.className = "pvtColLabel"
-                    th.innerHTML = colKey[j]
+                    th.innerHTML = opts.formatHeaders(c, colKey[j])
                     th.setAttribute("colspan", x)
                     if parseInt(j) == colAttrs.length-1 and rowAttrs.length != 0
                         th.setAttribute("rowspan", 2)
@@ -462,7 +464,7 @@ callWithJQuery ($) ->
                 if x != -1
                     th = document.createElement("th")
                     th.className = "pvtRowLabel"
-                    th.innerHTML = txt
+                    th.innerHTML = opts.formatHeaders(rowAttrs[j], txt)
                     th.setAttribute("rowspan", x)
                     if parseInt(j) == rowAttrs.length-1 and colAttrs.length !=0
                         th.setAttribute("colspan",2)


### PR DESCRIPTION
Hi Nicolas, this change would allow customizing row and column headers (or labels?) without having to keep large chunks of HTML in the data. See the example.

It may also be used for custom sorting - use integer indices and render the labels. :-)

Thanks for an awesome library!

Martian