### PR TITLE
<button> to <input type='button'>

### DIFF
--- a/pivot.coffee
+++ b/pivot.coffee
@@ -636,9 +636,9 @@ callWithJQuery ($) ->
                         valueList.append $("<p>").html(opts.localeStrings.tooMany)
                     else
                         btns = $("<p>").appendTo(valueList)
-                        btns.append $("<button>", {type:"button"}).html(opts.localeStrings.selectAll).bind "click", ->
+                        btns.append $("<input>", {type:"button"}).val(opts.localeStrings.selectAll).bind "click", ->
                             valueList.find("input:visible").prop "checked", true
-                        btns.append $("<button>", {type:"button"}).html(opts.localeStrings.selectNone).bind "click", ->
+                        btns.append $("<input>", {type:"button"}).val(opts.localeStrings.selectNone).bind "click", ->
                             valueList.find("input:visible").prop "checked", false
                         btns.append $("<input>", {type: "text", placeholder: opts.localeStrings.filterResults, class: "pvtSearch"}).bind "keyup", ->
                             filter = $(this).val().toLowerCase()
@@ -677,7 +677,7 @@ callWithJQuery ($) ->
                             valueList.toggle(0, refresh)
 
                     $("<p>").appendTo(valueList)
-                        .append $("<button>", {type:"button"}).text("OK").bind "click", updateFilter
+                        .append $("<input>", {type:"button"}).val("OK").bind "click", updateFilter
 
                     showFilterList = (e) ->
                         valueList.css(left: e.pageX, top: e.pageY).toggle()


### PR DESCRIPTION
If pivot table is inside a form and the form does not have a submit button, filter buttons submits the form. Changing `<button>` to `<input type="button">` solves the issue.