### PR TITLE
Moved from HTML to text calls to repair XSS vulnerability

### DIFF
--- a/pivot.coffee
+++ b/pivot.coffee
@@ -419,14 +419,14 @@ callWithJQuery ($) ->
                 tr.appendChild th
             th = document.createElement("th")
             th.className = "pvtAxisLabel"
-            th.innerHTML = c
+            th.textContent = c
             tr.appendChild th
             for own i, colKey of colKeys
                 x = spanSize(colKeys, parseInt(i), parseInt(j))
                 if x != -1
                     th = document.createElement("th")
                     th.className = "pvtColLabel"
-                    th.innerHTML = colKey[j]
+                    th.textContent = colKey[j]
                     th.setAttribute("colspan", x)
                     if parseInt(j) == colAttrs.length-1 and rowAttrs.length != 0
                         th.setAttribute("rowspan", 2)
@@ -434,7 +434,7 @@ callWithJQuery ($) ->
             if parseInt(j) == 0
                 th = document.createElement("th")
                 th.className = "pvtTotalLabel"
-                th.innerHTML = opts.localeStrings.totals
+                th.textContent = opts.localeStrings.totals
                 th.setAttribute("rowspan", colAttrs.length + (if rowAttrs.length ==0 then 0 else 1))
                 tr.appendChild th
             result.appendChild tr
@@ -445,12 +445,12 @@ callWithJQuery ($) ->
             for own i, r of rowAttrs
                 th = document.createElement("th")
                 th.className = "pvtAxisLabel"
-                th.innerHTML = r
-                tr.appendChild th 
+                th.textContent = r
+                tr.appendChild th
             th = document.createElement("th")
             if colAttrs.length ==0
                 th.className = "pvtTotalLabel"
-                th.innerHTML = opts.localeStrings.totals
+                th.textContent = opts.localeStrings.totals
             tr.appendChild th
             result.appendChild tr
 
@@ -462,7 +462,7 @@ callWithJQuery ($) ->
                 if x != -1
                     th = document.createElement("th")
                     th.className = "pvtRowLabel"
-                    th.innerHTML = txt
+                    th.textContent = txt
                     th.setAttribute("rowspan", x)
                     if parseInt(j) == rowAttrs.length-1 and colAttrs.length !=0
                         th.setAttribute("colspan",2)
@@ -472,7 +472,7 @@ callWithJQuery ($) ->
                 val = aggregator.value()
                 td = document.createElement("td")
                 td.className = "pvtVal row#{i} col#{j}"
-                td.innerHTML = aggregator.format(val)
+                td.textContent = aggregator.format(val)
                 td.setAttribute("data-value", val)
                 tr.appendChild td
 
@@ -480,7 +480,7 @@ callWithJQuery ($) ->
             val = totalAggregator.value()
             td = document.createElement("td")
             td.className = "pvtTotal rowTotal"
-            td.innerHTML = totalAggregator.format(val)
+            td.textContent = totalAggregator.format(val)
             td.setAttribute("data-value", val)
             td.setAttribute("data-for", "row"+i)
             tr.appendChild td
@@ -490,7 +490,7 @@ callWithJQuery ($) ->
         tr = document.createElement("tr")
         th = document.createElement("th")
         th.className = "pvtTotalLabel"
-        th.innerHTML = opts.localeStrings.totals
+        th.textContent = opts.localeStrings.totals
         th.setAttribute("colspan", rowAttrs.length + (if colAttrs.length == 0 then 0 else 1))
         tr.appendChild th
         for own j, colKey of colKeys
@@ -498,7 +498,7 @@ callWithJQuery ($) ->
             val = totalAggregator.value()
             td = document.createElement("td")
             td.className = "pvtTotal colTotal"
-            td.innerHTML = totalAggregator.format(val)
+            td.textContent = totalAggregator.format(val)
             td.setAttribute("data-value", val)
             td.setAttribute("data-for", "col"+j)
             tr.appendChild td
@@ -506,7 +506,7 @@ callWithJQuery ($) ->
         val = totalAggregator.value()
         td = document.createElement("td")
         td.className = "pvtGrandTotal"
-        td.innerHTML = totalAggregator.format(val)
+        td.textContent = totalAggregator.format(val)
         td.setAttribute("data-value", val)
         tr.appendChild td
         result.appendChild tr
@@ -544,11 +544,11 @@ callWithJQuery ($) ->
                 result = opts.renderer(pivotData, opts.rendererOptions)
             catch e
                 console.error(e.stack) if console?
-                result = $("<span>").html opts.localeStrings.renderError
+                result = $("<span>").text opts.localeStrings.renderError
         catch e
             console.error(e.stack) if console?
-            result = $("<span>").html opts.localeStrings.computeError
-        
+            result = $("<span>").text opts.localeStrings.computeError
+
         x = this[0]
         x.removeChild(x.lastChild) while x.hasChildNodes()
         return @append result
@@ -611,7 +611,7 @@ callWithJQuery ($) ->
                 .appendTo(rendererControl)
                 .bind "change", -> refresh() #capture reference
             for own x of opts.renderers
-                $("<option>").val(x).html(x).appendTo(renderer)
+                $("<option>").val(x).text(x).appendTo(renderer)
 
 
             #axis list, including the double-click menu
@@ -642,12 +642,12 @@ callWithJQuery ($) ->
 
                     valueList.append $("<h4>").text("#{c} (#{keys.length})")
                     if keys.length > opts.menuLimit
-                        valueList.append $("<p>").html(opts.localeStrings.tooMany)
+                        valueList.append $("<p>").text(opts.localeStrings.tooMany)
                     else
                         btns = $("<p>").appendTo(valueList)
-                        btns.append $("<button>", {type:"button"}).html(opts.localeStrings.selectAll).bind "click", ->
+                        btns.append $("<button>", {type:"button"}).text(opts.localeStrings.selectAll).bind "click", ->
                             valueList.find("input:visible").prop "checked", true
-                        btns.append $("<button>", {type:"button"}).html(opts.localeStrings.selectNone).bind "click", ->
+                        btns.append $("<button>", {type:"button"}).text(opts.localeStrings.selectNone).bind "click", ->
                             valueList.find("input:visible").prop "checked", false
                         btns.append $("<br>")
                         btns.append $("<input>", {type: "text", placeholder: opts.localeStrings.filterResults, class: "pvtSearch"}).bind "keyup", ->
@@ -674,7 +674,7 @@ callWithJQuery ($) ->
                                 .attr("type", "checkbox").addClass('pvtFilter')
                                 .attr("checked", !filterItemExcluded).data("filter", [c,k])
                                 .appendTo filterItem
-                             filterItem.append $("<span>").html k
+                             filterItem.append $("<span>").text k
                              filterItem.append $("<span>").text " ("+v+")"
                              checkContainer.append $("<p>").append(filterItem)
 
@@ -716,7 +716,7 @@ callWithJQuery ($) ->
             aggregator = $("<select>").addClass('pvtAggregator')
                 .bind "change", -> refresh() #capture reference
             for own x of opts.aggregators
-                aggregator.append $("<option>").val(x).html(x)
+                aggregator.append $("<option>").val(x).text(x)
 
             $("<td>").addClass('pvtVals')
               .appendTo(tr1)

--- a/pivot.es.coffee
+++ b/pivot.es.coffee
@@ -18,9 +18,9 @@ callWithJQuery ($) ->
     $.pivotUtilities.locales.es = 
 
         localeStrings:
-            renderError: "Ocurri&oacute; un error durante la interpretaci&oacute;n de la tabla din&acute;mica."
-            computeError: "Ocurri&oacute; un error durante el c&acute;lculo de la tabla din&acute;mica."
-            uiRenderError: "Ocurri&oacute; un error durante el dibujado de la tabla din&acute;mica."
+            renderError: "Ocurrió un error durante la interpretación de la tabla din´mica."
+            computeError: "Ocurrió un error durante el c´lculo de la tabla din´mica."
+            uiRenderError: "Ocurrió un error durante el dibujado de la tabla din´mica."
             selectAll: "Seleccionar todo"
             selectNone: "Deseleccionar todo"
             tooMany: "(demasiados valores)"
@@ -30,8 +30,8 @@ callWithJQuery ($) ->
             by: "por"
         aggregators: 
             "Cuenta":                             tpl.count(frFmtInt)
-            "Cuenta de valores &uacute;nicos":          tpl.countUnique(frFmtInt)
-            "Lista de valores &uacute;nicos":           tpl.listUnique(", ")
+            "Cuenta de valores únicos":          tpl.countUnique(frFmtInt)
+            "Lista de valores únicos":           tpl.listUnique(", ")
             "Suma":                              tpl.sum(frFmt)
             "Suma de enteros":                   tpl.sum(frFmtInt)
             "Promedio":                            tpl.average(frFmt)
@@ -40,12 +40,12 @@ callWithJQuery ($) ->
             "Suma de sumas":                    tpl.sumOverSum(frFmt)
             "Cota 80% superior":        tpl.sumOverSumBound80(true, frFmt)
             "Cota 80% inferior":        tpl.sumOverSumBound80(false, frFmt)
-            "Proporci&oacute;n del total (suma)":      tpl.fractionOf(tpl.sum(),   "total", frFmtPct)
-            "Proporci&oacute;n de la fila (suma)":    tpl.fractionOf(tpl.sum(),   "row",   frFmtPct)
-            "Proporci&oacute;n de la columna (suma)":  tpl.fractionOf(tpl.sum(),   "col",   frFmtPct)
-            "Proporci&oacute;n del total (cuenta)":     tpl.fractionOf(tpl.count(), "total", frFmtPct)
-            "Proporci&oacute;n de la fila (cuenta)":   tpl.fractionOf(tpl.count(), "row",   frFmtPct)
-            "Proporci&oacute;n de la columna (cuenta)": tpl.fractionOf(tpl.count(), "col",   frFmtPct)
+            "Proporción del total (suma)":      tpl.fractionOf(tpl.sum(),   "total", frFmtPct)
+            "Proporción de la fila (suma)":    tpl.fractionOf(tpl.sum(),   "row",   frFmtPct)
+            "Proporción de la columna (suma)":  tpl.fractionOf(tpl.sum(),   "col",   frFmtPct)
+            "Proporción del total (cuenta)":     tpl.fractionOf(tpl.count(), "total", frFmtPct)
+            "Proporción de la fila (cuenta)":   tpl.fractionOf(tpl.count(), "row",   frFmtPct)
+            "Proporción de la columna (cuenta)": tpl.fractionOf(tpl.count(), "col",   frFmtPct)
 
         renderers:
             "Tabla":                           $.pivotUtilities.renderers["Table"]

--- a/pivot.fr.coffee
+++ b/pivot.fr.coffee
@@ -17,12 +17,12 @@ callWithJQuery ($) ->
 
     $.pivotUtilities.locales.fr = 
         localeStrings:
-            renderError: "Une erreur est survenue en dessinant le tableau crois&eacute;."
-            computeError: "Une erreur est survenue en calculant le tableau crois&eacute;."
-            uiRenderError: "Une erreur est survenue en dessinant l'interface du tableau crois&eacute; dynamique."
-            selectAll: "S&eacute;lectionner tout"
-            selectNone: "S&eacute;lectionner rien"
-            tooMany: "(trop de valeurs &agrave; afficher)"
+            renderError: "Une erreur est survenue en dessinant le tableau croisé."
+            computeError: "Une erreur est survenue en calculant le tableau croisé."
+            uiRenderError: "Une erreur est survenue en dessinant l'interface du tableau croisé dynamique."
+            selectAll: "Sélectionner tout"
+            selectNone: "Sélectionner rien"
+            tooMany: "(trop de valeurs à afficher)"
             filterResults: "Filtrer les valeurs"
             totals: "Totaux"
             vs: "sur"
@@ -38,8 +38,8 @@ callWithJQuery ($) ->
             "Minimum":                            tpl.min(frFmt)
             "Maximum":                            tpl.max(frFmt)
             "Ratio de sommes":                    tpl.sumOverSum(frFmt)
-            "Borne sup&eacute;rieure 80%":        tpl.sumOverSumBound80(true, frFmt)
-            "Borne inf&eacute;rieure 80%":        tpl.sumOverSumBound80(false, frFmt)
+            "Borne supérieure 80%":               tpl.sumOverSumBound80(true, frFmt)
+            "Borne inférieure 80%":               tpl.sumOverSumBound80(false, frFmt)
             "Somme en proportion du totale":      tpl.fractionOf(tpl.sum(),   "total", frFmtPct)
             "Somme en proportion de la ligne":    tpl.fractionOf(tpl.sum(),   "row",   frFmtPct)
             "Somme en proportion de la colonne":  tpl.fractionOf(tpl.sum(),   "col",   frFmtPct)
@@ -48,10 +48,10 @@ callWithJQuery ($) ->
             "Nombre en proportion de la colonne": tpl.fractionOf(tpl.count(), "col",   frFmtPct)
 
         renderers:
-            "Table":                           $.pivotUtilities.renderers["Table"]
-            "Table avec barres":               $.pivotUtilities.renderers["Table Barchart"]
-            "Carte de chaleur":                $.pivotUtilities.renderers["Heatmap"]
-            "Carte de chaleur par ligne":      $.pivotUtilities.renderers["Row Heatmap"]
-            "Carte de chaleur par colonne":    $.pivotUtilities.renderers["Col Heatmap"]
+            "Table":                        $.pivotUtilities.renderers["Table"]
+            "Table avec barres":            $.pivotUtilities.renderers["Table Barchart"]
+            "Carte de chaleur":             $.pivotUtilities.renderers["Heatmap"]
+            "Carte de chaleur par ligne":   $.pivotUtilities.renderers["Row Heatmap"]
+            "Carte de chaleur par colonne": $.pivotUtilities.renderers["Col Heatmap"]
 
 

--- a/pivot.pt.coffee
+++ b/pivot.pt.coffee
@@ -22,9 +22,9 @@ callWithJQuery ($) ->
     $.pivotUtilities.locales.pt = 
 
         localeStrings:
-            renderError: "Ocorreu um error ao renderizar os resultados da Tabela Din&atilde;mica."
-            computeError: "Ocorreu um error ao computar os resultados da Tabela Din&atilde;mica."
-            uiRenderError: "Ocorreu um error ao renderizar a interface da Tabela Din&atilde;mica."
+            renderError: "Ocorreu um error ao renderizar os resultados da Tabela Dinãmica."
+            computeError: "Ocorreu um error ao computar os resultados da Tabela Dinãmica."
+            uiRenderError: "Ocorreu um error ao renderizar a interface da Tabela Dinãmica."
             selectAll: "Selecionar Tudo"
             selectNone: "Selecionar Nenhum"
             tooMany: "(demais para listar)"
@@ -34,23 +34,23 @@ callWithJQuery ($) ->
             by: "por"
 
         aggregators:
-            "Contagem":                                     tpl.count(frFmtInt)
-            "Contagem de Valores &uacute;nicos":            tpl.countUnique(frFmtInt)
-            "Lista de Valores &uacute;nicos":               tpl.listUnique(", ")
-            "Soma":                                         tpl.sum(frFmt)
-            "Soma de Inteiros":                             tpl.sum(frFmtInt)
-            "Média":                                        tpl.average(frFmt)
-            "Mínimo":                                       tpl.min(frFmt)
-            "Máximo":                                       tpl.max(frFmt)
-            "Soma sobre Soma":                              tpl.sumOverSum(frFmt)
-            "Limite Superior a 80%":                        tpl.sumOverSumBound80(true, frFmt)
-            "Limite Inferior a 80%":                        tpl.sumOverSumBound80(false, frFmt)
-            "Soma como Fra&ccedil;&atilde;o do Total":      tpl.fractionOf(tpl.sum(),   "total", frFmtPct)
-            "Soma como Fra&ccedil;&atilde;o da Linha":      tpl.fractionOf(tpl.sum(),   "row",   frFmtPct)
-            "Soma como Fra&ccedil;&atilde;o da Coluna":     tpl.fractionOf(tpl.sum(),   "col",   frFmtPct)
-            "Contagem como Fra&ccedil;&atilde;o do Total":  tpl.fractionOf(tpl.count(), "total", frFmtPct)
-            "Contagem como Fra&ccedil;&atilde;o da Linha":  tpl.fractionOf(tpl.count(), "row",   frFmtPct)
-            "Contagem como Fra&ccedil;&atilde;o da Coluna": tpl.fractionOf(tpl.count(), "col",   frFmtPct)
+            "Contagem":                       tpl.count(frFmtInt)
+            "Contagem de Valores únicos":     tpl.countUnique(frFmtInt)
+            "Lista de Valores únicos":        tpl.listUnique(", ")
+            "Soma":                           tpl.sum(frFmt)
+            "Soma de Inteiros":               tpl.sum(frFmtInt)
+            "Média":                          tpl.average(frFmt)
+            "Mínimo":                         tpl.min(frFmt)
+            "Máximo":                         tpl.max(frFmt)
+            "Soma sobre Soma":                tpl.sumOverSum(frFmt)
+            "Limite Superior a 80%":          tpl.sumOverSumBound80(true, frFmt)
+            "Limite Inferior a 80%":          tpl.sumOverSumBound80(false, frFmt)
+            "Soma como Fração do Total":      tpl.fractionOf(tpl.sum(),   "total", frFmtPct)
+            "Soma como Fração da Linha":      tpl.fractionOf(tpl.sum(),   "row",   frFmtPct)
+            "Soma como Fração da Coluna":     tpl.fractionOf(tpl.sum(),   "col",   frFmtPct)
+            "Contagem como Fração do Total":  tpl.fractionOf(tpl.count(), "total", frFmtPct)
+            "Contagem como Fração da Linha":  tpl.fractionOf(tpl.count(), "row",   frFmtPct)
+            "Contagem como Fração da Coluna": tpl.fractionOf(tpl.count(), "col",   frFmtPct)
 
         renderers:
             "Tabela":                    r["Table"]
@@ -61,10 +61,10 @@ callWithJQuery ($) ->
 
     if gcr
         $.pivotUtilities.locales.pt.gchart_renderers =
-            "Gr&aacute;fico de Linhas":            gcr["Line Chart"]
-            "Gr&aacute;fico de Barras":            gcr["Bar Chart"]
-            "Gr&aacute;fico de Barras Empilhadas": gcr["Stacked Bar Chart"]
-            "Gr&aacute;fico de &Aacute;rea":       gcr["Area Chart"]
+            "Gráfico de Linhas":            gcr["Line Chart"]
+            "Gráfico de Barras":            gcr["Bar Chart"]
+            "Gráfico de Barras Empilhadas": gcr["Stacked Bar Chart"]
+            "Gráfico de Área":              gcr["Area Chart"]
 
     if d3r
         $.pivotUtilities.locales.pt.d3_renderers =
@@ -72,7 +72,7 @@ callWithJQuery ($) ->
 
     if c3r
       $.pivotUtilities.locales.pt.c3_renderers =
-        "Gr&aacute;fico de Linhas": c3r["Line Chart C3"]
-        "Gr&aacute;fico de Barras": c3r["Bar Chart C3"]
+        "Gráfico de Linhas": c3r["Line Chart C3"]
+        "Gráfico de Barras": c3r["Bar Chart C3"]
 
     return $.pivotUtilities.locales.pt

--- a/pivot.tr.coffee
+++ b/pivot.tr.coffee
@@ -22,57 +22,57 @@ callWithJQuery ($) ->
   $.pivotUtilities.locales.tr =
 
     localeStrings:
-      renderError: "PivotTable sonu&ccedil;lar&#305;n&#305; olu&#351;tuturken hata olu&#351;tu"
-      computeError: "PivotTable sonu&ccedil;lar&#305;n&#305; i&#351;lerken hata olu&#351;tu"
-      uiRenderError: "PivotTable UI sonu&ccedil;lar&#305;n&#305; olu&#351;tuturken hata olu&#351;tu"
-      selectAll: "T&uuml;m&uuml;n&uuml; Se&ccedil;"
-      selectNone: "T&uuml;m&uuml;n&uuml; B&#305;rak"
-      tooMany: "(listelemek i&ccedil;in fazla)"
-      filterResults: "Sonu&ccedil;lar&#305; filtrele"
+      renderError: "PivotTable sonuçlarını oluştuturken hata oluştu"
+      computeError: "PivotTable sonuçlarını işlerken hata oluştu"
+      uiRenderError: "PivotTable UI sonuçlarını oluştuturken hata oluştu"
+      selectAll: "Tümünü Seç"
+      selectNone: "Tümünü Bırak"
+      tooMany: "(listelemek için fazla)"
+      filterResults: "Sonuçları filtrele"
       totals: "Toplam"
       vs: "vs"
       by: "ile"
 
     aggregators:
-      "Say&#305;": tpl.count(frFmtInt)
-      "Benzersiz de&#287;erler say&#305;s&#305;": tpl.countUnique(frFmtInt)
-      "Benzersiz de&#287;erler listesi": tpl.listUnique(", ")
+      "Sayı": tpl.count(frFmtInt)
+      "Benzersiz değerler sayısı": tpl.countUnique(frFmtInt)
+      "Benzersiz değerler listesi": tpl.listUnique(", ")
       "Toplam": tpl.sum(frFmt)
-      "Toplam (tam say&#305;)": tpl.sum(frFmtInt)
+      "Toplam (tam sayı)": tpl.sum(frFmtInt)
       "Ortalama": tpl.average(frFmt)
       "Min": tpl.min(frFmt)
       "Maks": tpl.max(frFmt)
-      "Miktarlar&#305;n toplam&#305;": tpl.sumOverSum(frFmt)
-      "%80 daha y&uuml;ksek": tpl.sumOverSumBound80(true, frFmt)
-      "%80 daha d&uuml;&#351;&uuml;k": tpl.sumOverSumBound80(false, frFmt)
-      "Toplam oran&#305; (toplam)": tpl.fractionOf(tpl.sum(), "total", frFmtPct)
-      "Sat&#305;r oran&#305; (toplam)": tpl.fractionOf(tpl.sum(), "row", frFmtPct)
-      "S&uuml;tunun oran&#305; (toplam)": tpl.fractionOf(tpl.sum(), "col", frFmtPct)
-      "Toplam oran&#305; (say&#305;)": tpl.fractionOf(tpl.count(), "total", frFmtPct)
-      "Sat&#305;r oran&#305; (say&#305;)": tpl.fractionOf(tpl.count(), "row", frFmtPct)
-      "S&uuml;tunun oran&#305; (say&#305;)": tpl.fractionOf(tpl.count(), "col", frFmtPct)
+      "Miktarların toplamı": tpl.sumOverSum(frFmt)
+      "%80 daha yüksek": tpl.sumOverSumBound80(true, frFmt)
+      "%80 daha düşük": tpl.sumOverSumBound80(false, frFmt)
+      "Toplam oranı (toplam)": tpl.fractionOf(tpl.sum(), "total", frFmtPct)
+      "Satır oranı (toplam)": tpl.fractionOf(tpl.sum(), "row", frFmtPct)
+      "Sütunun oranı (toplam)": tpl.fractionOf(tpl.sum(), "col", frFmtPct)
+      "Toplam oranı (sayı)": tpl.fractionOf(tpl.count(), "total", frFmtPct)
+      "Satır oranı (sayı)": tpl.fractionOf(tpl.count(), "row", frFmtPct)
+      "Sütunun oranı (sayı)": tpl.fractionOf(tpl.count(), "col", frFmtPct)
 
     renderers:
       "Tablo": r["Table"]
-      "Tablo (&Ccedil;ubuklar)": r["Table Barchart"]
-      "&#304;lgi haritas&#305;": r["Heatmap"]
-      "Sat&#305;r ilgi haritas&#305;": r["Row Heatmap"]
-      "S&uuml;tun ilgi haritas&#305;": r["Col Heatmap"]
+      "Tablo (Çubuklar)": r["Table Barchart"]
+      "İlgi haritası": r["Heatmap"]
+      "Satır ilgi haritası": r["Row Heatmap"]
+      "Sütun ilgi haritası": r["Col Heatmap"]
   if gcr
     $.pivotUtilities.locales.tr.gchart_renderers =
-      "&Ccedil;izgi Grafi&#287;i (gchart)": gcr["Line Chart"]
-      "Bar Grafi&#287;i (gchart)": gcr["Bar Chart"]
-      "Y&#305;&#287;&#305;lm&#305;&#351; &Ccedil;ubuk Grafik (gchart)": gcr["Stacked Bar Chart"]
-      "Alan Grafi&#287;i (gchart)": gcr["Area Chart"]
+      "Çizgi Grafiği (gchart)": gcr["Line Chart"]
+      "Bar Grafiği (gchart)": gcr["Bar Chart"]
+      "Yığılmış Çubuk Grafik (gchart)": gcr["Stacked Bar Chart"]
+      "Alan Grafiği (gchart)": gcr["Area Chart"]
 
   if d3r
     $.pivotUtilities.locales.tr.d3_renderers =
-      "Hiyerar&#351;ik Alan Grafi&#287;i (Treemap)": d3r["Treemap"]
+      "Hiyerarşik Alan Grafiği (Treemap)": d3r["Treemap"]
 
   if c3r
     $.pivotUtilities.locales.tr.c3_renderers =
-      "&Ccedil;izgi Grafi&#287;i (C3)": c3r["Line Chart C3"]
-      "Bar Grafi&#287;i (C3)": c3r["Bar Chart C3"]
+      "Çizgi Grafiği (C3)": c3r["Line Chart C3"]
+      "Bar Grafiği (C3)": c3r["Bar Chart C3"]
 
   return $.pivotUtilities.locales.tr
 


### PR DESCRIPTION
In `1.4.0`, there was a change from text based calls (e.g. `textContent` and `text()`) to HTML based calls (e.g. `innerHTML` and `html()`). While this was done in good spirit (e.g. to add better localization support), it opened an XSS vulnerability.

How to reproduce the XSS vulnerabilty:

- Open `examples/simple.html` in editor
- Replace `{color: "blue", shape: "circle"},` with `{color: "<scr" + "ipt>alert(1)</scr" + "ipt>", shape: "circle"},`
- Open `examples/simple.html` in browser
- See `alert(1)` on screen

![screen shot 2015-11-03 at 4 36 24 pm](https://cloud.githubusercontent.com/assets/902488/10923923/20d70942-8249-11e5-92ce-6827cfc4fa4e.png)

Previous to `1.4.0` and after this PR is landed, this will render the script as text:

![screen shot 2015-11-03 at 4 36 46 pm](https://cloud.githubusercontent.com/assets/902488/10923927/28788928-8249-11e5-9f92-18df0585eae4.png)

If you are unfamiliar with XSS, more information can be found here: https://www.owasp.org/index.php/Cross-site_Scripting_%28XSS%29

This PR resolves that by moving back to text based properties and methods (effectively reverting https://github.com/nicolaskruchten/pivottable/commit/8b11f193911b90f89f467a602280403c034445e6, https://github.com/nicolaskruchten/pivottable/commit/8eed5079d0b5b5e7b988ec865d11ee2e16b30ee9). 

In this PR:

- Replaced `innerHTML` with `textContent`
- Replaced `html()` with `text()`
- Replaced HTML entities with unicode equivalents

**Missing:**

We would love to add tests for this but were unable to find any in this repo =(