### PR TITLE
Fixed typo in language string in some locale files

### DIFF
--- a/locales/pivot.de.coffee
+++ b/locales/pivot.de.coffee
@@ -15,7 +15,7 @@ callWithJQuery ($) ->
     frFmtInt = nf(digitsAfterDecimal: 0, thousandsSep: " ", decimalSep: ",")
     frFmtPct = nf(digitsAfterDecimal: 1, scaler: 100, suffix: "%", thousandsSep: " ", decimalSep: ",")
 
-    $.pivotUtilities.locales.fr = 
+    $.pivotUtilities.locales.de = 
         localeStrings:
             renderError: "Bei der Darstellung der Pivot-Tabelle ist ein Fehler aufgetreten."
             computeError: "Bei der Berechnung der Pivot-Tabelle ist ein Fehler aufgetreten."

--- a/locales/pivot.it.coffee
+++ b/locales/pivot.it.coffee
@@ -15,7 +15,7 @@ callWithJQuery ($) ->
   frFmtInt = nf(digitsAfterDecimal: 0, thousandsSep: " ", decimalSep: ",")
   frFmtPct = nf(digitsAfterDecimal: 1, scaler: 100, suffix: "%", thousandsSep: " ", decimalSep: ",")
 
-  $.pivotUtilities.locales.fr =
+  $.pivotUtilities.locales.it =
     localeStrings:
       renderError: "Si è verificato un errore durante la creazione della tabella."
       computeError: "Si è verificato un errore di calcolo nella tabella."

--- a/locales/pivot.nl.coffee
+++ b/locales/pivot.nl.coffee
@@ -15,7 +15,7 @@ callWithJQuery ($) ->
     frFmtInt = nf(digitsAfterDecimal: 0, thousandsSep: " ", decimalSep: ",")
     frFmtPct = nf(digitsAfterDecimal: 1, scaler: 100, suffix: "%", thousandsSep: " ", decimalSep: ",")
 
-    $.pivotUtilities.locales.fr = 
+    $.pivotUtilities.locales.nl = 
         localeStrings:
             renderError: "Er is een fout opgetreden bij het renderen van de kruistabel."
             computeError: "Er is een fout opgetreden bij het berekenen van de kruistabel."


### PR DESCRIPTION
Hi,
I noticed a small error in some of the locale files which prevents loading the languages with the correct language strings.
Example: If you use the pivot.de.js file and try to load the german language-pack by using "de" as parameter, the table isn't shown because "de" can't be found. If you use "fr" the table is rendered correctly (with german labels).
I've created this pull request with fixed language keys.