### PR TITLE
Fix italian locale name

### DIFF
--- a/locales/pivot.it.coffee
+++ b/locales/pivot.it.coffee
@@ -15,7 +15,7 @@ callWithJQuery ($) ->
   frFmtInt = nf(digitsAfterDecimal: 0, thousandsSep: " ", decimalSep: ",")
   frFmtPct = nf(digitsAfterDecimal: 1, scaler: 100, suffix: "%", thousandsSep: " ", decimalSep: ",")
 
-  $.pivotUtilities.locales.fr =
+  $.pivotUtilities.locales.it =
     localeStrings:
       renderError: "Si è verificato un errore durante la creazione della tabella."
       computeError: "Si è verificato un errore di calcolo nella tabella."


### PR DESCRIPTION
The italian locale was mistakenly still called `fr`. This creates problem when using both the locales in the same application.

So this PR is basically a typo fix, there's not much to say