### PR TITLE
Properties not correctly identified

### DIFF
--- a/dist/pivot.js
+++ b/dist/pivot.js
@@ -1005,11 +1005,13 @@
         input = PivotData.convertToArray(input);
         tblCols = (function() {
           var ref, results;
-          ref = input[0];
           results = [];
-          for (k in ref) {
-            if (!hasProp.call(ref, k)) continue;
-            results.push(k);
+          for (var i = 0; i < input.length; i++) {
+            ref = input[i];
+            for (k in ref) {
+              if (!hasProp.call(ref, k)) continue;
+              results.push(k);
+            }
           }
           return results;
         })();


### PR DESCRIPTION
When using **Java JAX-RS API** and converting some objects to JSON, if an object does not have a property, it is not included into JSON response. When Pivottable uses first array position to identify columns (`input[0]`) and this position does not have some property it throws an javascript exception, like this:

```
pivot.coffee:874 TypeError: Cannot read property '13' of undefined
    at pivot.min.js:1040
    at Function.e.forEachRecord (pivot.coffee:288)
    at n.t.fn.pivotUI (pivot.coffee:603)
```

I really do not know if it is correct to assume that different properties might come from the Java response and it is up to Pivottable to understand that.

I do not know Coffee programming, so I did the change on the dist file, sorry if I did it wrong. I tried both 2.1.0 and 2.3.0 versions. Both have the same logic.

**Edited:**
I have tested my solution for many (~10.000) JSON objects and it hung up the browser. I am going to better test.