### PR TITLE
Adding rowTotal and colTotal CSS classes to total labels

### DIFF
--- a/pivot.coffee
+++ b/pivot.coffee
@@ -488,7 +488,7 @@ callWithJQuery ($) ->
                 tr.appendChild th
             th = document.createElement("th")
             if colAttrs.length ==0
-                th.className = "pvtTotalLabel"
+                th.className = "pvtTotalLabel rowTotal"
                 th.innerHTML = opts.localeStrings.totals
             tr.appendChild th
             thead.appendChild tr
@@ -534,7 +534,7 @@ callWithJQuery ($) ->
         #finally, the row for col totals, and a grand total
         tr = document.createElement("tr")
         th = document.createElement("th")
-        th.className = "pvtTotalLabel"
+        th.className = "pvtTotalLabel colTotal"
         th.innerHTML = opts.localeStrings.totals
         th.setAttribute("colspan", rowAttrs.length + (if colAttrs.length == 0 then 0 else 1))
         tr.appendChild th


### PR DESCRIPTION
I noticed that hiding .rowTotal and .colTotal does not hide the titles. I've added the CSS classes to the th elements too.

Let me know if this is the correct way of doing this.