### PR TITLE
Adds check for empty thousands separator

### DIFF
--- a/src/pivot.coffee
+++ b/src/pivot.coffee
@@ -19,7 +19,7 @@ callWithJQuery ($) ->
         x1 = x[0]
         x2 = if x.length > 1 then  decimalSep + x[1] else ''
         rgx = /(\d+)(\d{3})/
-        x1 = x1.replace(rgx, '$1' + thousandsSep + '$2') while rgx.test(x1)
+        x1 = x1.replace(rgx, '$1' + thousandsSep + '$2') while rgx.test(x1) if thousandsSep
         return x1 + x2
 
     numberFormat = (opts) ->

--- a/tests/pivot_spec.coffee
+++ b/tests/pivot_spec.coffee
@@ -532,6 +532,11 @@ describe "$.pivotUtilities", ->
             expect nf 1234567.89123456
             .toEqual "1a234a567b89"
 
+        it "adds blank thousands separator", ->
+            nf = numberFormat(thousandsSep: "", decimalSep: "b")
+            expect nf 1234567.89123456
+            .toEqual "1234567b89"
+
         it "adds prefixes and suffixes", ->
             nf = numberFormat(prefix: "a", suffix: "b")
             expect nf 1234567.89123456


### PR DESCRIPTION
A check is added for empty thousands separator so it is possible to render numbers without a thousands separator
https://github.com/nicolaskruchten/pivottable/issues/914