### PR TITLE
Heatmap to color cells even when all the values are the same

### DIFF
--- a/src/pivot.coffee
+++ b/src/pivot.coffee
@@ -1059,7 +1059,7 @@ callWithJQuery ($) ->
             min = Math.min(values...)
             max = Math.max(values...)
             return (x) ->
-                nonRed = 255 - Math.round 255*(x-min)/(max-min)
+                nonRed = 255 - if max == min then 0 else Math.round 255*(x-min)/(max-min)
                 return "rgb(255,#{nonRed},#{nonRed})"
 
         heatmapper = (scope) =>


### PR DESCRIPTION
Currently when the table only plots one possible value (e.g., table of
NULL and 1), the cells with a value have no color. I thought this is
counterintuitive, so I tried a custom heatmap using the weather example.
Indeed, using Plotly as below I can get the same heatmap as now, but
when my table only has a single possible value I can still tell the
cells with values from those with no value because they are white.

```
    rendererOptions: {
        heatmap: {
            colorScaleGenerator: function(values) {
                var min, max;
                min = Math.min.apply(Math, values);
                max = Math.max.apply(Math, values);
                return Plotly.d3.scale.linear()
                    .domain([min, max])
                    .range(["white", "red"])
                ;
            }
        }
    },

```
