### PR TITLE
[ENH] Large tables: Fixed headers (freeze headers for pivot table row…

### DIFF
--- a/dist/pivot.css
+++ b/dist/pivot.css
@@ -112,3 +112,20 @@ table.pvtTable tbody tr td {
 .pvtCheckContainer p{ margin: 5px; }
 
 .pvtRendererArea { padding: 5px;}
+
+.pvtTable thead {
+    position: -webkit-sticky; /* for Safari */
+    position: sticky;
+    top: 0;
+    z-index: 2;
+}
+    
+.pvtTable tbody th {
+    position: sticky;
+    position: -webkit-sticky;
+    width: 100px;
+    min-width: 100px;
+    max-width: 100px;
+    left: 0px;
+    z-index: 1;
+}


### PR DESCRIPTION
Issue #593 

As you suggested, this modification has no javascript, everything is CSS, it freezes the headers for PivotTable rows and columns, but only the column closest to cells (the very last one), other wise it should require some JS.