### PR TITLE
[ENH] Drag and drop on mobile without touchpunch

### DIFF
--- a/dist/pivot.js
+++ b/dist/pivot.js
@@ -1754,6 +1754,74 @@
     };
 
     /*
+    Support Touch Event
+     */
+    var supportTouch = function () {
+        $.support.touch = true;
+
+        if (!$.support.touch) {
+            return;
+        }
+
+        var proto = $.ui.mouse.prototype,
+            _mouseInit = proto._mouseInit;
+
+        $.extend(proto, {
+            _getElementToBind: function() {
+                var el = this.element;
+                return el;
+            },
+
+            _mouseInit: function() {
+                this._getElementToBind().bind("touchstart." + this.widgetName, $.proxy(this, "_touchStart"));
+                _mouseInit.apply(this, arguments);
+            },
+
+            _touchStart: function(event) {
+                if (event.originalEvent.targetTouches.length != 1) {
+                    return false;
+                }
+
+                if (!this._mouseCapture(event, false)) {
+                    return true;
+                }
+
+                this.element
+                    .bind("touchmove." + this.widgetName, $.proxy(this, "_touchMove"))
+                    .bind("touchend." + this.widgetName, $.proxy(this, "_touchEnd"));
+
+                this._modifyEvent(event);
+
+                $(document).trigger($.Event("mouseup"));
+                this._mouseDown(event);
+
+                return false;
+            },
+
+            _touchMove: function(event) {
+                this._modifyEvent(event);
+                this._mouseMove(event);
+            },
+
+            _touchEnd: function(event) {
+                this.element
+                    .unbind("touchmove." + this.widgetName)
+                    .unbind("touchend." + this.widgetName);
+                this._mouseUp(event);
+            },
+
+            _modifyEvent: function(event) {
+                event.which = 1;
+                var target = event.originalEvent.targetTouches[0];
+                event.pageX = target.clientX;
+                event.pageY = target.clientY;
+            }
+
+        });
+    }
+    supportTouch();
+
+    /*
     Barchart post-processing
      */
     return $.fn.barchart = function(opts) {

--- a/examples/fully_loaded.html
+++ b/examples/fully_loaded.html
@@ -8,7 +8,6 @@
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script>
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui-touch-punch/0.2.3/jquery.ui.touch-punch.min.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.11/c3.min.js"></script>
 
         <!-- PivotTable.js libs from ../dist -->

--- a/examples/onrefresh.html
+++ b/examples/onrefresh.html
@@ -14,7 +14,6 @@
         </style>
 
         <!-- optional: mobile support with jqueryui-touch-punch -->
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui-touch-punch/0.2.3/jquery.ui.touch-punch.min.js"></script>
 
         <!-- for examples only! script to show code to user -->
         <script type="text/javascript" src="show_code.js"></script>


### PR DESCRIPTION
The drag and drop does not work on mobile devices unless you use jqueryui-touch-punch as it says here https://github.com/nicolaskruchten/pivottable/issues/330#issuecomment-100721415.
This pull request causes the events to be translated on the mobile devices so that the drag and drop works there.

Note: I made some neat modifications to the Javascript and want help 'porting' back up to the CoffeeScript version